### PR TITLE
Merge deprecation comment changes into master

### DIFF
--- a/common/config/eslint/eslint.config.deprecation-policy.js
+++ b/common/config/eslint/eslint.config.deprecation-policy.js
@@ -23,7 +23,7 @@ module.exports = [
         "warn",
         {
           removeOldDates: true,
-          addVersion: "5.2.2"
+          addVersion: "5.2.3"
         }
       ]
     }

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,7 +2,11 @@
   {
     "policyName": "prerelease-monorepo-lockStep",
     "definitionName": "lockStepVersion",
+<<<<<<< HEAD
     "version": "5.2.0-dev.14",
+=======
+    "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
     "nextBump": "prerelease"
   }
 ]

--- a/core/backend/CHANGELOG.json
+++ b/core/backend/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-backend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-backend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-backend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-backend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-backend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-backend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js backend components",
   "main": "lib/cjs/core-backend.js",
   "module": "lib/esm/core-backend.js",

--- a/core/bentley/CHANGELOG.json
+++ b/core/bentley/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-bentley",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-bentley_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-bentley_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-bentley_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-bentley_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-bentley_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/bentley/CHANGELOG.md
+++ b/core/bentley/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-bentley
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/bentley/package.json
+++ b/core/bentley/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-bentley",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Bentley JavaScript core components",
   "main": "lib/cjs/core-bentley.js",
   "module": "lib/esm/core-bentley.js",

--- a/core/common/CHANGELOG.json
+++ b/core/common/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-common_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-common_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-common_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-common_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "fix bug where iModel crs extent latitude would always be 0 on desktop"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-common_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/common/CHANGELOG.md
+++ b/core/common/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/core-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- fix bug where iModel crs extent latitude would always be 0 on desktop
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-common",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js components common to frontend and backend",
   "main": "lib/cjs/core-common.js",
   "module": "lib/esm/core-common.js",

--- a/core/ecschema-editing/CHANGELOG.json
+++ b/core/ecschema-editing/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/ecschema-editing",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecschema-editing_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecschema-editing_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecschema-editing_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-editing_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecschema-editing_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/ecschema-editing/CHANGELOG.md
+++ b/core/ecschema-editing/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/ecschema-editing
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/ecschema-editing/package.json
+++ b/core/ecschema-editing/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-editing",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "ECSchema editing and validation API",
   "license": "MIT",
   "main": "lib/cjs/ecschema-editing.js",

--- a/core/ecschema-locaters/CHANGELOG.json
+++ b/core/ecschema-locaters/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/ecschema-locaters",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecschema-locaters_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecschema-locaters_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecschema-locaters_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-locaters_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecschema-locaters_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/ecschema-locaters/CHANGELOG.md
+++ b/core/ecschema-locaters/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/ecschema-locaters
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/ecschema-locaters/package.json
+++ b/core/ecschema-locaters/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-locaters",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "EC Schema file locaters",
   "license": "MIT",
   "main": "lib/cjs/ecschema-locaters.js",

--- a/core/ecschema-metadata/CHANGELOG.json
+++ b/core/ecschema-metadata/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema-metadata",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecschema-metadata_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecschema-metadata_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecschema-metadata_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-metadata_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add FormatSetFormatsProvider"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecschema-metadata_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/ecschema-metadata/CHANGELOG.md
+++ b/core/ecschema-metadata/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/ecschema-metadata
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Add FormatSetFormatsProvider
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/ecschema-metadata/package.json
+++ b/core/ecschema-metadata/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-metadata",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "ECObjects core concepts in typescript",
   "license": "MIT",
   "main": "lib/cjs/ecschema-metadata.js",

--- a/core/ecschema-rpc/common/CHANGELOG.json
+++ b/core/ecschema-rpc/common/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema-rpcinterface-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-rpcinterface-common_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Moved exception handling of 'schema not found' to backend implementation to avoid RPC error logging."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecschema-rpcinterface-common_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/ecschema-rpc/common/CHANGELOG.md
+++ b/core/ecschema-rpc/common/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/ecschema-rpcinterface-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Moved exception handling of 'schema not found' to backend implementation to avoid RPC error logging.
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/ecschema-rpc/common/package.json
+++ b/core/ecschema-rpc/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-rpcinterface-common",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Schema RPC Interface common interface",
   "main": "lib/cjs/ecschema-rpc-interface.js",
   "module": "lib/esm/ecschema-rpc-interface.js",

--- a/core/ecschema-rpc/impl/CHANGELOG.json
+++ b/core/ecschema-rpc/impl/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/ecschema-rpcinterface-impl",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-rpcinterface-impl_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Moved exception handling of 'schema not found' to backend implementation to avoid RPC error logging."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecschema-rpcinterface-impl_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/ecschema-rpc/impl/CHANGELOG.md
+++ b/core/ecschema-rpc/impl/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/ecschema-rpcinterface-impl
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Moved exception handling of 'schema not found' to backend implementation to avoid RPC error logging.
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/ecschema-rpc/impl/package.json
+++ b/core/ecschema-rpc/impl/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-rpcinterface-impl",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Schema RPC Interface backend implementation",
   "main": "lib/cjs/ecschema-rpc-impl.js",
   "module": "lib/esm/ecschema-rpc-impl.js",

--- a/core/ecsql/common/CHANGELOG.json
+++ b/core/ecsql/common/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/ecsql-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecsql-common_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecsql-common_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecsql-common_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecsql-common_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecsql-common_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/ecsql/common/CHANGELOG.md
+++ b/core/ecsql/common/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/ecsql-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/ecsql/common/package.json
+++ b/core/ecsql/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecsql-common",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "ECSql component that can be reference on backend and frontend",
   "main": "lib/cjs/ecsql-common.js",
   "module": "lib/esm/ecsql-common.js",

--- a/core/electron/CHANGELOG.json
+++ b/core/electron/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-electron",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-electron_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-electron_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-electron_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-electron_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-electron_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/electron/CHANGELOG.md
+++ b/core/electron/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-electron
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-electron",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js ElectronHost and ElectronApp",
   "license": "MIT",
   "engines": {

--- a/core/express-server/CHANGELOG.json
+++ b/core/express-server/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/express-server",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/express-server_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/express-server_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/express-server_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/express-server_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/express-server_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/express-server/CHANGELOG.md
+++ b/core/express-server/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/express-server
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/express-server/package.json
+++ b/core/express-server/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/express-server",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js express utilities",
   "main": "lib/cjs/express-server.js",
   "module": "lib/esm/express-server.js",

--- a/core/extension/CHANGELOG.json
+++ b/core/extension/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-extension",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-extension_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-extension_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-extension_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-extension_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-extension_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/extension/CHANGELOG.md
+++ b/core/extension/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-extension
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/extension/package.json
+++ b/core/extension/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-extension",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js Extension API",
   "type": "module",
   "typings": "index.d.ts",

--- a/core/frontend-devtools/CHANGELOG.json
+++ b/core/frontend-devtools/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/frontend-devtools",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/frontend-devtools_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/frontend-devtools_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/frontend-devtools_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/frontend-devtools_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/frontend-devtools_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/frontend-devtools/CHANGELOG.md
+++ b/core/frontend-devtools/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/frontend-devtools
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/frontend-devtools/package.json
+++ b/core/frontend-devtools/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/frontend-devtools",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Debug menu and supporting UI widgets",
   "main": "lib/cjs/frontend-devtools.js",
   "module": "lib/esm/frontend-devtools.js",

--- a/core/frontend/CHANGELOG.json
+++ b/core/frontend/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "@itwin/core-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-frontend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-frontend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-frontend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-frontend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Changed queryExtents to use ECSqlReader"
+          },
+          {
+            "comment": "Add support for new KindOfQuantity for coordinate length"
+          },
+          {
+            "comment": "Improve frame rate during interactive editing."
+          },
+          {
+            "comment": "A model drawn as only contour lines will only mask the background map where the contour lines draw."
+          },
+          {
+            "comment": "Fix an exception when terrain is enabled."
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-frontend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/frontend/CHANGELOG.md
+++ b/core/frontend/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Change Log - @itwin/core-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Changed queryExtents to use ECSqlReader
+- Add support for new KindOfQuantity for coordinate length
+- Improve frame rate during interactive editing.
+- A model drawn as only contour lines will only mask the background map where the contour lines draw.
+- Fix an exception when terrain is enabled.
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-frontend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js frontend components",
   "main": "lib/cjs/core-frontend.js",
   "module": "lib/esm/core-frontend.js",

--- a/core/geometry/CHANGELOG.json
+++ b/core/geometry/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-geometry",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-geometry_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-geometry_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-geometry_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-geometry_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-geometry_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/geometry/CHANGELOG.md
+++ b/core/geometry/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-geometry
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/geometry/package.json
+++ b/core/geometry/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-geometry",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js Core Geometry library",
   "main": "lib/cjs/core-geometry.js",
   "module": "lib/esm/core-geometry.js",

--- a/core/hypermodeling/CHANGELOG.json
+++ b/core/hypermodeling/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/hypermodeling-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/hypermodeling-frontend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/hypermodeling-frontend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/hypermodeling-frontend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/hypermodeling-frontend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/hypermodeling-frontend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/hypermodeling/CHANGELOG.md
+++ b/core/hypermodeling/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/hypermodeling-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/hypermodeling/package.json
+++ b/core/hypermodeling/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/hypermodeling-frontend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js hypermodeling package",
   "main": "lib/cjs/hypermodeling-frontend.js",
   "module": "lib/esm/hypermodeling-frontend.js",

--- a/core/i18n/CHANGELOG.json
+++ b/core/i18n/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-i18n",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-i18n_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-i18n_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-i18n_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-i18n_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-i18n_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/i18n/CHANGELOG.md
+++ b/core/i18n/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-i18n
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/i18n/package.json
+++ b/core/i18n/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-i18n",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js localization code",
   "main": "lib/cjs/core-i18n.js",
   "module": "lib/esm/core-i18n.js",

--- a/core/markup/CHANGELOG.json
+++ b/core/markup/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-markup",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-markup_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-markup_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-markup_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-markup_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-markup_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/markup/CHANGELOG.md
+++ b/core/markup/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-markup
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/markup/package.json
+++ b/core/markup/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-markup",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js markup package",
   "main": "lib/cjs/core-markup.js",
   "module": "lib/esm/core-markup.js",

--- a/core/mobile/CHANGELOG.json
+++ b/core/mobile/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-mobile",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-mobile_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-mobile_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-mobile_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-mobile_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-mobile_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/mobile/CHANGELOG.md
+++ b/core/mobile/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-mobile
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/mobile/package.json
+++ b/core/mobile/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-mobile",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js MobileHost and MobileApp",
   "license": "MIT",
   "engines": {

--- a/core/orbitgt/CHANGELOG.json
+++ b/core/orbitgt/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/core-orbitgt",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-orbitgt_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-orbitgt_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-orbitgt_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-orbitgt_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-orbitgt_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/orbitgt/CHANGELOG.md
+++ b/core/orbitgt/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/core-orbitgt
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/orbitgt/package.json
+++ b/core/orbitgt/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-orbitgt",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "",
   "main": "lib/cjs/core-orbitgt.js",
   "module": "lib/esm/core-orbitgt.js",

--- a/core/quantity/CHANGELOG.json
+++ b/core/quantity/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/core-quantity",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/core-quantity_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/core-quantity_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/core-quantity_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/core-quantity_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Add documentation to public methods"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/core-quantity_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/quantity/CHANGELOG.md
+++ b/core/quantity/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/core-quantity
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Add documentation to public methods
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/quantity/package.json
+++ b/core/quantity/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/core-quantity",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Quantity parsing, formatting and conversions for iModel.js",
   "main": "lib/cjs/core-quantity.js",
   "module": "lib/esm/core-quantity.js",

--- a/core/webgl-compatibility/CHANGELOG.json
+++ b/core/webgl-compatibility/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/webgl-compatibility",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/webgl-compatibility_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/webgl-compatibility_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/webgl-compatibility_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/webgl-compatibility_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/webgl-compatibility_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/core/webgl-compatibility/CHANGELOG.md
+++ b/core/webgl-compatibility/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/webgl-compatibility
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/core/webgl-compatibility/package.json
+++ b/core/webgl-compatibility/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/webgl-compatibility",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "APIs for determining the level of compatibility of a browser+device with the iTwin.js rendering system.",
   "license": "MIT",
   "main": "lib/cjs/webgl-compatibility.js",

--- a/domains/analytical/backend/CHANGELOG.json
+++ b/domains/analytical/backend/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/analytical-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/analytical-backend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/analytical-backend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/analytical-backend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/analytical-backend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Revert analytical-backend from pure esm to cjs/esm"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/analytical-backend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/domains/analytical/backend/CHANGELOG.md
+++ b/domains/analytical/backend/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/analytical-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Revert analytical-backend from pure esm to cjs/esm
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/domains/analytical/backend/package.json
+++ b/domains/analytical/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/analytical-backend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "main": "lib/cjs/analytical-backend.js",
   "module": "lib/esm/analytical-backend.js",
   "typings": "lib/cjs/analytical-backend",

--- a/domains/linear-referencing/backend/CHANGELOG.json
+++ b/domains/linear-referencing/backend/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/linear-referencing-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/linear-referencing-backend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/linear-referencing-backend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/linear-referencing-backend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/linear-referencing-backend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Revert linear-referencing-backend from pure esm to cjs/esm"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/linear-referencing-backend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/domains/linear-referencing/backend/CHANGELOG.md
+++ b/domains/linear-referencing/backend/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/linear-referencing-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Revert linear-referencing-backend from pure esm to cjs/esm
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/domains/linear-referencing/backend/package.json
+++ b/domains/linear-referencing/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/linear-referencing-backend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "main": "lib/cjs/linear-referencing-backend.js",
   "module": "lib/esm/linear-referencing-backend.js",
   "typings": "lib/cjs/linear-referencing-backend",

--- a/domains/linear-referencing/common/CHANGELOG.json
+++ b/domains/linear-referencing/common/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/linear-referencing-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/linear-referencing-common_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/linear-referencing-common_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/linear-referencing-common_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/linear-referencing-common_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Revert linear-referencing-common from pure esm to cjs/esm"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/linear-referencing-common_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/domains/linear-referencing/common/CHANGELOG.md
+++ b/domains/linear-referencing/common/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/linear-referencing-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Revert linear-referencing-common from pure esm to cjs/esm
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/domains/linear-referencing/common/package.json
+++ b/domains/linear-referencing/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/linear-referencing-common",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "main": "lib/cjs/linear-referencing-common.js",
   "module": "lib/esm/linear-referencing-common.js",
   "typings": "lib/cjs/linear-referencing-common",

--- a/domains/physical-material/backend/CHANGELOG.json
+++ b/domains/physical-material/backend/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/physical-material-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/physical-material-backend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/physical-material-backend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/physical-material-backend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/physical-material-backend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Revert physical-material-backend from pure esm to cjs/esm"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/physical-material-backend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/domains/physical-material/backend/CHANGELOG.md
+++ b/domains/physical-material/backend/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/physical-material-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Revert physical-material-backend from pure esm to cjs/esm
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/domains/physical-material/backend/package.json
+++ b/domains/physical-material/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/physical-material-backend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "main": "lib/cjs/physical-material-backend.js",
   "module": "lib/esm/physical-material-backend.js",
   "typings": "lib/cjs/physical-material-backend",

--- a/editor/backend/CHANGELOG.json
+++ b/editor/backend/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/editor-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/editor-backend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/editor-backend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/editor-backend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/editor-backend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/editor-backend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/editor/backend/CHANGELOG.md
+++ b/editor/backend/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/editor-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/editor/backend/package.json
+++ b/editor/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/editor-backend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js editor backend",
   "main": "lib/cjs/editor-backend.js",
   "module": "lib/esm/editor-backend.js",

--- a/editor/common/CHANGELOG.json
+++ b/editor/common/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/editor-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/editor-common_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/editor-common_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/editor-common_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/editor-common_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/editor-common_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/editor/common/CHANGELOG.md
+++ b/editor/common/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/editor-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/editor/common/package.json
+++ b/editor/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/editor-common",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js editing properties common to frontend and backend",
   "main": "lib/cjs/editor-common.js",
   "module": "lib/esm/editor-common.js",

--- a/editor/frontend/CHANGELOG.json
+++ b/editor/frontend/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/editor-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/editor-frontend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/editor-frontend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/editor-frontend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/editor-frontend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/editor-frontend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/editor/frontend/CHANGELOG.md
+++ b/editor/frontend/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/editor-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/editor/frontend/package.json
+++ b/editor/frontend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/editor-frontend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js frontend components",
   "main": "lib/cjs/editor-frontend.js",
   "module": "lib/esm/editor-frontend.js",

--- a/extensions/frontend-tiles/CHANGELOG.json
+++ b/extensions/frontend-tiles/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/frontend-tiles",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/frontend-tiles_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/frontend-tiles_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/frontend-tiles_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/frontend-tiles_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/frontend-tiles_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/extensions/frontend-tiles/CHANGELOG.md
+++ b/extensions/frontend-tiles/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/frontend-tiles
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/extensions/frontend-tiles/package.json
+++ b/extensions/frontend-tiles/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/frontend-tiles",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Experimental alternative technique for visualizing the contents of iModels",
   "main": "lib/cjs/frontend-tiles.js",
   "module": "lib/esm/frontend-tiles.js",

--- a/extensions/map-layers-auth/CHANGELOG.json
+++ b/extensions/map-layers-auth/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/map-layers-auth",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/map-layers-auth_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/map-layers-auth_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/map-layers-auth_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/map-layers-auth_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/map-layers-auth_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/extensions/map-layers-auth/CHANGELOG.md
+++ b/extensions/map-layers-auth/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/map-layers-auth
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/extensions/map-layers-auth/package.json
+++ b/extensions/map-layers-auth/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/map-layers-auth",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Extension that adds a Map Layers Widget",
   "main": "lib/cjs/map-layers-auth.js",
   "module": "lib/esm/map-layers-auth.js",

--- a/extensions/map-layers-formats/CHANGELOG.json
+++ b/extensions/map-layers-formats/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/map-layers-formats",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/map-layers-formats_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/map-layers-formats_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/map-layers-formats_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/map-layers-formats_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/map-layers-formats_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/extensions/map-layers-formats/CHANGELOG.md
+++ b/extensions/map-layers-formats/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/map-layers-formats
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/extensions/map-layers-formats/package.json
+++ b/extensions/map-layers-formats/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/map-layers-formats",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Enables additional map-layers formats in iTwin.js",
   "main": "lib/cjs/map-layers-formats.js",
   "module": "lib/esm/map-layers-formats.js",

--- a/full-stack-tests/ecschema-rpc-interface/CHANGELOG.json
+++ b/full-stack-tests/ecschema-rpc-interface/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/ecschema-rpcinterface-tests",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema-rpcinterface-tests_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecschema-rpcinterface-tests_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/full-stack-tests/ecschema-rpc-interface/CHANGELOG.md
+++ b/full-stack-tests/ecschema-rpc-interface/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/ecschema-rpcinterface-tests
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/full-stack-tests/ecschema-rpc-interface/package.json
+++ b/full-stack-tests/ecschema-rpc-interface/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/ecschema-rpcinterface-tests",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Integration tests for the Schema RPC Interface",
   "author": {
     "name": "Bentley Systems, Inc.",

--- a/full-stack-tests/rpc-interface/CHANGELOG.json
+++ b/full-stack-tests/rpc-interface/CHANGELOG.json
@@ -2,6 +2,39 @@
   "name": "@itwin/rpcinterface-full-stack-tests",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/rpcinterface-full-stack-tests_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Added additional tests for queryExtents"
+          }
+        ]
+      }
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/rpcinterface-full-stack-tests_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/full-stack-tests/rpc-interface/CHANGELOG.md
+++ b/full-stack-tests/rpc-interface/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log - @itwin/rpcinterface-full-stack-tests
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+### Updates
+
+- Added additional tests for queryExtents
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/full-stack-tests/rpc-interface/package.json
+++ b/full-stack-tests/rpc-interface/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/rpcinterface-full-stack-tests",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Test the full iTwin.js Core stack (frontend and backend) using standard RPC interfaces",
   "license": "MIT",
   "scripts": {

--- a/presentation/backend/CHANGELOG.json
+++ b/presentation/backend/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/presentation-backend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/presentation-backend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/presentation-backend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/presentation-backend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/presentation-backend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/presentation-backend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/presentation/backend/CHANGELOG.md
+++ b/presentation/backend/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/presentation-backend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/presentation-backend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Backend of iTwin.js Presentation library",
   "license": "MIT",
   "repository": {

--- a/presentation/common/CHANGELOG.json
+++ b/presentation/common/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/presentation-common",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/presentation-common_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/presentation-common_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/presentation-common_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/presentation-common_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/presentation-common_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/presentation/common/CHANGELOG.md
+++ b/presentation/common/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/presentation-common
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/presentation/common/package.json
+++ b/presentation/common/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/presentation-common",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Common pieces for iModel.js presentation packages",
   "license": "MIT",
   "repository": {

--- a/presentation/frontend/CHANGELOG.json
+++ b/presentation/frontend/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/presentation-frontend",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/presentation-frontend_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/presentation-frontend_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/presentation-frontend_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/presentation-frontend_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/presentation-frontend_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/presentation/frontend/CHANGELOG.md
+++ b/presentation/frontend/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/presentation-frontend
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/presentation-frontend",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Frontend of iModel.js Presentation library",
   "license": "MIT",
   "repository": {

--- a/tools/build/CHANGELOG.json
+++ b/tools/build/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/build-tools",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/build-tools_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/build-tools_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/build-tools_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/build-tools_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/build-tools_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/tools/build/CHANGELOG.md
+++ b/tools/build/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/build-tools
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/build-tools",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Bentley build tools",
   "license": "MIT",
   "repository": {

--- a/tools/certa/CHANGELOG.json
+++ b/tools/certa/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/certa",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/certa_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/certa_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/certa_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/certa_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/certa_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/tools/certa/CHANGELOG.md
+++ b/tools/certa/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/certa
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/certa",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "A mocha-based integration test runner",
   "license": "MIT",
   "main": "bin/certa.js",

--- a/tools/ecschema2ts/CHANGELOG.json
+++ b/tools/ecschema2ts/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/ecschema2ts",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/ecschema2ts_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/ecschema2ts_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/ecschema2ts_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/ecschema2ts_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/ecschema2ts_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/tools/ecschema2ts/CHANGELOG.md
+++ b/tools/ecschema2ts/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/ecschema2ts
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/tools/ecschema2ts/package.json
+++ b/tools/ecschema2ts/package.json
@@ -2,7 +2,11 @@
   "name": "@itwin/ecschema2ts",
   "description": "Command line tools that takes an ECSchema xml file and outputs a typescript module",
   "license": "MIT",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "bin": {
     "ecschema2ts": "./bin/index.js"
   },

--- a/tools/perf-tools/CHANGELOG.json
+++ b/tools/perf-tools/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/perf-tools",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/perf-tools_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/perf-tools_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/perf-tools_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/perf-tools_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/perf-tools_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/tools/perf-tools/CHANGELOG.md
+++ b/tools/perf-tools/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/perf-tools
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/tools/perf-tools/package.json
+++ b/tools/perf-tools/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/perf-tools",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "Tools for collecting and reporting performance data",
   "main": "lib/cjs/perf-tools.js",
   "typings": "lib/cjs/perf-tools",

--- a/ui/appui-abstract/CHANGELOG.json
+++ b/ui/appui-abstract/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/appui-abstract",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/appui-abstract_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/appui-abstract_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/appui-abstract_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/appui-abstract_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/appui-abstract_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/ui/appui-abstract/CHANGELOG.md
+++ b/ui/appui-abstract/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/appui-abstract
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/ui/appui-abstract/package.json
+++ b/ui/appui-abstract/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@itwin/appui-abstract",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "description": "iTwin.js UI abstractions",
   "main": "lib/cjs/appui-abstract.js",
   "module": "lib/esm/appui-abstract.js",

--- a/utils/workspace-editor/CHANGELOG.json
+++ b/utils/workspace-editor/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@itwin/workspace-editor",
   "entries": [
     {
+<<<<<<< HEAD
+=======
+      "version": "5.2.3",
+      "tag": "@itwin/workspace-editor_v5.2.3",
+      "date": "Thu, 28 Aug 2025 07:18:14 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.2",
+      "tag": "@itwin/workspace-editor_v5.2.2",
+      "date": "Thu, 28 Aug 2025 06:58:19 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.1",
+      "tag": "@itwin/workspace-editor_v5.2.1",
+      "date": "Thu, 28 Aug 2025 06:43:56 GMT",
+      "comments": {}
+    },
+    {
+      "version": "5.2.0",
+      "tag": "@itwin/workspace-editor_v5.2.0",
+      "date": "Thu, 28 Aug 2025 06:27:37 GMT",
+      "comments": {}
+    },
+    {
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
       "version": "5.1.4",
       "tag": "@itwin/workspace-editor_v5.1.4",
       "date": "Fri, 22 Aug 2025 14:22:33 GMT",

--- a/utils/workspace-editor/CHANGELOG.md
+++ b/utils/workspace-editor/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Change Log - @itwin/workspace-editor
 
+<<<<<<< HEAD
 This log was last generated on Fri, 22 Aug 2025 14:26:46 GMT and should not be manually modified.
+=======
+This log was last generated on Thu, 28 Aug 2025 07:18:14 GMT and should not be manually modified.
+
+## 5.2.3
+Thu, 28 Aug 2025 07:18:14 GMT
+
+_Version update only_
+
+## 5.2.2
+Thu, 28 Aug 2025 06:58:19 GMT
+
+_Version update only_
+
+## 5.2.1
+Thu, 28 Aug 2025 06:43:56 GMT
+
+_Version update only_
+
+## 5.2.0
+Thu, 28 Aug 2025 06:27:37 GMT
+
+_Version update only_
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
 
 ## 5.1.4
 Fri, 22 Aug 2025 14:22:33 GMT

--- a/utils/workspace-editor/package.json
+++ b/utils/workspace-editor/package.json
@@ -2,7 +2,11 @@
   "name": "@itwin/workspace-editor",
   "license": "MIT",
   "main": "lib/WorkspaceEditor.js",
+<<<<<<< HEAD
   "version": "5.2.0-dev.14",
+=======
+  "version": "5.2.3",
+>>>>>>> cfa3d74eb8 (Apply deprecation date rule for v5.2.3)
   "bin": {
     "WorkspaceEditor": "./lib/WorkspaceEditor.js"
   },


### PR DESCRIPTION
This PR contains all changes after running lint-deprecation ESLint rule and merging with master. Manual intervention required: solve conflicts in this branch and merge PR into master. This happened because deprecation comments in master and in release branch could not be merged automatically. @iTwin/itwinjs-core-admins